### PR TITLE
Fixing install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ conda install -y -c conda-forge \
   ninja \
   boost \
   ccache \
-  eigen \
+  "eigen=3.4.0" \
   flann \
   freeimage \
   lz4-c \


### PR DESCRIPTION
For me, not pinning eigen to 3.4.0 breaks the installation.

Currently will automatically get a newer version which breaks the installation in further steps.

Consider adding this fix to avoid pain for others.